### PR TITLE
fix owner authorization

### DIFF
--- a/packages/graphql/server/resolvers/mutators.ts
+++ b/packages/graphql/server/resolvers/mutators.ts
@@ -1,11 +1,11 @@
 /*
 
 
-Mutations have five steps:
+Mutations have six steps:
 
 1. Authorization
 
-First we check if the user requesting the mutation has the authorization to do so.
+First we check if the document exists and if the user requesting the mutation has the authorization to do so.
 
 2. Validation
 
@@ -58,6 +58,7 @@ import { restrictViewableFields } from "@vulcanjs/permissions";
 const validateMutationData = async ({
   model,
   data,
+  originalDocument,
   mutatorName,
   context,
   properties,
@@ -67,12 +68,14 @@ const validateMutationData = async ({
   context: Object; // Graphql context
   properties: Object; // arguments of the callback, can vary depending on the mutator
   data?: any; // data to validate
+  originalDocument?: VulcanDocument;
   validationFunction?: Function;
 }): Promise<void> => {
   const { typeName } = model.graphql;
   // basic simple schema validation
   const simpleSchemaValidationErrors = validateData({
     document: data,
+    originalDocument,
     model,
     context,
     mutatorName,
@@ -399,14 +402,6 @@ export const updateMutator = async <TModel extends VulcanDocument>({
     asAdmin,
   });
 
-  if (!currentDocument) {
-    throw new Error(
-      `Could not find document to update for selector: ${JSON.stringify(
-        selector
-      )}`
-    );
-  }
-
   /*
 
   Properties
@@ -427,6 +422,7 @@ export const updateMutator = async <TModel extends VulcanDocument>({
     await validateMutationData({
       model,
       data,
+      originalDocument: properties.originalDocument,
       mutatorName,
       context,
       properties,
@@ -572,14 +568,6 @@ export const deleteMutator = async <TModel extends VulcanDocument>({
     operationName: "delete",
     asAdmin,
   });
-
-  if (!document) {
-    throw new Error(
-      `Could not find document to delete for selector: ${JSON.stringify(
-        selector
-      )}`
-    );
-  }
 
   /*
 

--- a/packages/graphql/server/resolvers/validation.ts
+++ b/packages/graphql/server/resolvers/validation.ts
@@ -84,6 +84,7 @@ const validateDocumentPermissions = (
 };
 
 interface ValidateDataInput {
+  originalDocument?: VulcanDocument;
   document: VulcanDocument;
   model: VulcanModel;
   context: any;
@@ -99,6 +100,7 @@ interface ValidateDataInput {
 
 */
 export const validateData = ({
+  originalDocument,
   document,
   model,
   context,
@@ -115,7 +117,7 @@ export const validateData = ({
   }
   // validate operation permissions on each field (and other Vulcan-specific constraints)
   validationErrors = validationErrors.concat(
-    validateDocumentPermissions(document, document, schema, context, mutatorName)
+    validateDocumentPermissions(originalDocument ? originalDocument : document, document, schema, context, mutatorName)
   );
   // build the schema on the fly
   // TODO: does it work with nested schema???

--- a/packages/permissions/permissions.ts
+++ b/packages/permissions/permissions.ts
@@ -23,6 +23,7 @@ import {
   VulcanDocument,
   forEachDocumentField,
 } from "@vulcanjs/schema";
+import { isEqual } from "lodash";
 
 // TODO: define user as a specific VulcanModel? So we get the typing already
 export interface User extends VulcanDocument {
@@ -170,7 +171,9 @@ export const owns = function (user: User | null, document: VulcanDocument) {
   try {
     if (!!document.userId) {
       // case 1: document is a post or a comment, use userId to check
-      return user._id === document.userId;
+      // Can't use "===" nor "==" here because of mongoDB ids types.
+      // TODO: check https://github.com/VulcanJS/vulcan-npm/issues/63
+      return isEqual(user._id, document.userId);
     } else {
       // case 2: document is a user, use _id or slug to check
       return document.slug


### PR DESCRIPTION
small improvements here:
- document existence checking was performed two times in the update and delete mutators
- the update mutator never detected "owners" group because the original document wasn't transmitted, so the authorization didn't access to the document's userId prop
- there was a bug comparing ids by server side because of MongoDB ids types, see #63 