### PR TITLE
allow graphql operators in filter query

### DIFF
--- a/packages/permissions/permissions.ts
+++ b/packages/permissions/permissions.ts
@@ -293,6 +293,13 @@ export const checkFields = (
   const ambiguousFields = getDocumentBasedPermissionFieldNames(model); // these fields need to wait for the document to be present before being checked
   const fieldsToTest = difference(fields, ambiguousFields); // we only check non-ambiguous fields (canRead: ["guests", "admins"] for instance)
   const diff = difference(fieldsToTest, viewableFields);
+  
+  //allow GraphQL operators: _and, _or, or _not as the filter:
+  const allowedOperators: string[] = ['$and','$or', '$not'];
+  //diff is valid it is one of the allowed operators
+  if((diff.length==1 && typeof diff[0] == 'string') && allowedOperators.indexOf(diff[0])>-1){
+    return true
+  }
 
   if (diff.length) {
     throw new Error(


### PR DESCRIPTION
GraphQL filters such as `_and`, `_or` or `_not` throws a permissions issue: "You don't have permission to filter model Letter by the following fields: $and. Field is not readable or do not exist." it looks like it's being treated as a field?

to reproduce issue, try an _and query, something like this in /api/graphql:
```
query {
  vulcanUsers(
    input: { filter: { _and: [{ _id: { _eq: "61ccb24e536dde646bdb3080" } }] } }
  ) {
    results {
      _id
    }
  }
}
```
This patch will check if the permissions diff is an graphQl operator, and allow the query to continue if so.
