### PR TITLE
Feature/next 12 2

### DIFF
--- a/starters/next/package.json
+++ b/starters/next/package.json
@@ -140,7 +140,7 @@
     "lodash": "^4.17.19",
     "mongoose": "6",
     "nanoid": "^3.1.25",
-    "next": "^12.1.6",
+    "next": "latest",
     "next-connect": "^0.9.1",
     "next-i18next": "^8.10.0",
     "next-mdx-remote": "3",

--- a/starters/next/src/middleware.ts
+++ b/starters/next/src/middleware.ts
@@ -1,0 +1,22 @@
+import { NextFetchEvent, NextRequest } from "next/server";
+import {
+  debugMatcher,
+  debugMiddleware,
+} from "~/vulcan-demo/edge-middlewares/debugMiddleware";
+import {
+  megaparamMatcher,
+  megaParamMiddleware,
+} from "~/vulcan-demo/edge-middlewares/megaparamMiddleware";
+
+export function middleware(req: NextRequest, event: NextFetchEvent) {
+  // TODO: how to reuse the "debugMatcher" which is not really a regex?
+  if (req.url.match(/debug/)) {
+    return debugMiddleware(req, event);
+  }
+  if (req.url.match(/megaparam-demo/)) {
+    return megaParamMiddleware(req, event);
+  }
+}
+export const config = {
+  matchers: [debugMatcher, megaparamMatcher],
+};

--- a/starters/next/src/middleware.ts
+++ b/starters/next/src/middleware.ts
@@ -18,5 +18,5 @@ export function middleware(req: NextRequest, event: NextFetchEvent) {
   }
 }
 export const config = {
-  matchers: [debugMatcher, megaparamMatcher],
+  matchers: [debugMatcher], //, megaparamMatcher],
 };

--- a/starters/next/src/pages/api/vn/examples/megaparam-form.tsx
+++ b/starters/next/src/pages/api/vn/examples/megaparam-form.tsx
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export default async (req: NextRequest) => {
+  // TODO: this doesn't work because we cannot use a POST request here
+  // otherwise we fail to redirect using a GET afterwards
+  // const formData = await req.formData();
+  // const theme = formData.get("theme")?.toString();
+  // const company = formData.get("company")?.toString();
+  const url = new URL(req.url);
+  const theme = url.searchParams.get("theme");
+  const company = url.searchParams.get("company");
+
+  // Redirect back to the page with an absolute URL
+  const pageUrl = new URL("/vn/examples/megaparam-demo", req.url);
+  const res = NextResponse.redirect(pageUrl);
+
+  if (theme && ["light", "dark"].includes(theme)) {
+    res.cookies.set("theme", theme);
+  }
+  if (company) {
+    res.cookies.set("my_company", company);
+  }
+  return res;
+};
+
+export const config = {
+  runtime: "experimental-edge",
+};

--- a/starters/next/src/pages/vn/examples/[M]/megaparam-demo.tsx
+++ b/starters/next/src/pages/vn/examples/[M]/megaparam-demo.tsx
@@ -2,7 +2,7 @@
 // src/vulcan-demo/edge-middlewares/megaparamMiddleware.ts
 import { GetStaticPaths } from "next";
 import { GetStaticProps, InferGetStaticPropsType } from "next";
-import { useRouter } from "next/dist/client/router";
+// import { useRouter } from "next/router";
 
 /**
  * Run the server and open
@@ -12,7 +12,7 @@ export const MegaparamDemo = ({
   params,
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
   const { theme, company } = params;
-  const router = useRouter();
+  //const router = useRouter();
   return (
     <div
       style={{
@@ -43,6 +43,11 @@ export const MegaparamDemo = ({
         </a>
       </p>
       <form
+        action="/api/vn/examples/megaparam-form"
+        // If you use a POST method, you won't be able to redirect back to the form using a edge API handler
+        //method="POST"
+        /*
+        Old JS version
         onSubmit={(evt) => {
           evt.preventDefault();
           const theme = evt.target["theme"]?.value;
@@ -50,7 +55,7 @@ export const MegaparamDemo = ({
           (window as any).cookieStore.set("company", company);
           (window as any).cookieStore.set("theme", theme);
           router.reload();
-        }}
+        }}*/
       >
         <label htmlFor="theme">Pick a theme:</label>
         <select id="theme" name="theme" defaultValue={theme}>

--- a/starters/next/src/pages/vn/examples/[M]/megaparam-demo.tsx
+++ b/starters/next/src/pages/vn/examples/[M]/megaparam-demo.tsx
@@ -1,3 +1,5 @@
+// NOTE: after Next 12.2 update, the corresponding middleware now lives in
+// src/vulcan-demo/edge-middlewares/megaparamMiddleware.ts
 import { GetStaticPaths } from "next";
 import { GetStaticProps, InferGetStaticPropsType } from "next";
 import { useRouter } from "next/dist/client/router";

--- a/starters/next/src/vulcan-demo/edge-middlewares/debugMiddleware.ts
+++ b/starters/next/src/vulcan-demo/edge-middlewares/debugMiddleware.ts
@@ -1,6 +1,8 @@
 import { NextFetchEvent, NextRequest, NextResponse } from "next/server";
 
-export function middleware(req: NextRequest, ev: NextFetchEvent) {
+export const debugMatcher = "/vn/debug/:path*";
+
+export function debugMiddleware(req: NextRequest, ev: NextFetchEvent) {
   // @see https://nextjs.org/docs/messages/middleware-relative-urls
   if (
     process.env.NODE_ENV === "production" &&

--- a/starters/next/src/vulcan-demo/edge-middlewares/megaparamMiddleware.ts
+++ b/starters/next/src/vulcan-demo/edge-middlewares/megaparamMiddleware.ts
@@ -1,8 +1,9 @@
-import type { NextFetchEvent, NextRequest } from "next/server";
-import { NextResponse } from "next/server";
-import { encode } from "./megaparam-demo";
+import { NextFetchEvent, NextRequest, NextResponse } from "next/server";
 
-export function middleware(req: NextRequest, event: NextFetchEvent) {
+import { encode } from "~/pages/vn/examples/[M]/megaparam-demo";
+export const megaparamMatcher = "/vn/examples/:M/megaparam-demo";
+// @see https://blog.vulcanjs.org/render-anything-statically-with-next-js-and-the-megaparam-4039e66ffde
+export function megaParamMiddleware(req: NextRequest, event: NextFetchEvent) {
   // get the current params from the cookies, eg theme
   // you can also get them from headers, url, route params...
   const theme = (req.cookies["theme"] || "light") as "light" | "dark";

--- a/starters/next/src/vulcan-demo/edge-middlewares/megaparamMiddleware.ts
+++ b/starters/next/src/vulcan-demo/edge-middlewares/megaparamMiddleware.ts
@@ -6,12 +6,20 @@ export const megaparamMatcher = "/vn/examples/:M/megaparam-demo";
 export function megaParamMiddleware(req: NextRequest, event: NextFetchEvent) {
   // get the current params from the cookies, eg theme
   // you can also get them from headers, url, route params...
-  const theme = (req.cookies["theme"] || "light") as "light" | "dark";
-  const company = req.cookies["company"] || "Unknown_company";
+  const theme = req.cookies.get("theme") || "light";
+  if (!["light", "dark"].includes(theme)) {
+    throw new Error(
+      `Valid themes are light and dark, received ${theme}. Clear your cookies and try again.`
+    );
+  }
+  const company = req.cookies.get("company") || "Unknown_company";
   // Here, you could run some checks, like
   // verifying that current user can actually access this company
   // and that the theme is valid
   const isValid = true;
+  if (!isValid) {
+    throw new Error("User cannot access company");
+  }
   // convert to a megaparam
   const megaparam = encode({
     theme,
@@ -20,12 +28,5 @@ export function megaParamMiddleware(req: NextRequest, event: NextFetchEvent) {
   // This patterns guarantee that the URL is absolute
   req.nextUrl.pathname = `/vn/examples/${megaparam}/megaparam-demo`;
   const res = NextResponse.rewrite(req.nextUrl);
-  // remember theme if not yet done
-  if (!req.cookies["theme"]) {
-    res.cookies["theme"] = theme;
-  }
-  if (!req.cookies["company"]) {
-    res.cookies["my_company"] = theme;
-  }
   return res;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4628,10 +4628,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/env@npm:12.1.6"
-  checksum: e6a4f189f0d653d13dc7ad510f6c9d2cf690bfd9e07c554bd501b840f8dabc3da5adcab874b0bc01aab86c3647cff4fb84692e3c3b28125af26f0b05cd4c7fcf
+"@next/env@npm:12.2.0":
+  version: 12.2.0
+  resolution: "@next/env@npm:12.2.0"
+  checksum: 5fb317bdb5eb2d5df12ff55e335368792dba21874c5ece3cabf8cd312cec911a1d54ecf368e69dc08640b0244669b8a98c86cd035c7874b17640602e67c1b9d9
   languageName: node
   linkType: hard
 
@@ -4663,86 +4663,93 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-android-arm-eabi@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-android-arm-eabi@npm:12.1.6"
+"@next/swc-android-arm-eabi@npm:12.2.0":
+  version: 12.2.0
+  resolution: "@next/swc-android-arm-eabi@npm:12.2.0"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@next/swc-android-arm64@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-android-arm64@npm:12.1.6"
+"@next/swc-android-arm64@npm:12.2.0":
+  version: 12.2.0
+  resolution: "@next/swc-android-arm64@npm:12.2.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-darwin-arm64@npm:12.1.6"
+"@next/swc-darwin-arm64@npm:12.2.0":
+  version: 12.2.0
+  resolution: "@next/swc-darwin-arm64@npm:12.2.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-darwin-x64@npm:12.1.6"
+"@next/swc-darwin-x64@npm:12.2.0":
+  version: 12.2.0
+  resolution: "@next/swc-darwin-x64@npm:12.2.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm-gnueabihf@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-linux-arm-gnueabihf@npm:12.1.6"
+"@next/swc-freebsd-x64@npm:12.2.0":
+  version: 12.2.0
+  resolution: "@next/swc-freebsd-x64@npm:12.2.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-arm-gnueabihf@npm:12.2.0":
+  version: 12.2.0
+  resolution: "@next/swc-linux-arm-gnueabihf@npm:12.2.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-linux-arm64-gnu@npm:12.1.6"
+"@next/swc-linux-arm64-gnu@npm:12.2.0":
+  version: 12.2.0
+  resolution: "@next/swc-linux-arm64-gnu@npm:12.2.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-linux-arm64-musl@npm:12.1.6"
+"@next/swc-linux-arm64-musl@npm:12.2.0":
+  version: 12.2.0
+  resolution: "@next/swc-linux-arm64-musl@npm:12.2.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-linux-x64-gnu@npm:12.1.6"
+"@next/swc-linux-x64-gnu@npm:12.2.0":
+  version: 12.2.0
+  resolution: "@next/swc-linux-x64-gnu@npm:12.2.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-linux-x64-musl@npm:12.1.6"
+"@next/swc-linux-x64-musl@npm:12.2.0":
+  version: 12.2.0
+  resolution: "@next/swc-linux-x64-musl@npm:12.2.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-win32-arm64-msvc@npm:12.1.6"
+"@next/swc-win32-arm64-msvc@npm:12.2.0":
+  version: 12.2.0
+  resolution: "@next/swc-win32-arm64-msvc@npm:12.2.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-ia32-msvc@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-win32-ia32-msvc@npm:12.1.6"
+"@next/swc-win32-ia32-msvc@npm:12.2.0":
+  version: 12.2.0
+  resolution: "@next/swc-win32-ia32-msvc@npm:12.2.0"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-win32-x64-msvc@npm:12.1.6"
+"@next/swc-win32-x64-msvc@npm:12.2.0":
+  version: 12.2.0
+  resolution: "@next/swc-win32-x64-msvc@npm:12.2.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -8501,6 +8508,15 @@ __metadata:
   bin:
     swcx: run_swcx.js
   checksum: 12820ebbe2a668872ad60c0be0d0d3ca93539a4068719f3f3d731539505bb2ad145ece80b8666b1b6ef4c56c4e1e22a59b40adf4874f1a8c31f6a47347a00c88
+  languageName: node
+  linkType: hard
+
+"@swc/helpers@npm:0.4.2":
+  version: 0.4.2
+  resolution: "@swc/helpers@npm:0.4.2"
+  dependencies:
+    tslib: ^2.4.0
+  checksum: 0b8c86ad03b17b8fe57dc4498e25dc294ea6bc42558a6b92d8fcd789351dac80199409bef38a2e3ac06aae0fedddfc0ab9c34409acbf74e55d1bbbd74f68b6b7
   languageName: node
   linkType: hard
 
@@ -26606,26 +26622,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:^12.1.6":
-  version: 12.1.6
-  resolution: "next@npm:12.1.6"
+"next@npm:latest":
+  version: 12.2.0
+  resolution: "next@npm:12.2.0"
   dependencies:
-    "@next/env": 12.1.6
-    "@next/swc-android-arm-eabi": 12.1.6
-    "@next/swc-android-arm64": 12.1.6
-    "@next/swc-darwin-arm64": 12.1.6
-    "@next/swc-darwin-x64": 12.1.6
-    "@next/swc-linux-arm-gnueabihf": 12.1.6
-    "@next/swc-linux-arm64-gnu": 12.1.6
-    "@next/swc-linux-arm64-musl": 12.1.6
-    "@next/swc-linux-x64-gnu": 12.1.6
-    "@next/swc-linux-x64-musl": 12.1.6
-    "@next/swc-win32-arm64-msvc": 12.1.6
-    "@next/swc-win32-ia32-msvc": 12.1.6
-    "@next/swc-win32-x64-msvc": 12.1.6
+    "@next/env": 12.2.0
+    "@next/swc-android-arm-eabi": 12.2.0
+    "@next/swc-android-arm64": 12.2.0
+    "@next/swc-darwin-arm64": 12.2.0
+    "@next/swc-darwin-x64": 12.2.0
+    "@next/swc-freebsd-x64": 12.2.0
+    "@next/swc-linux-arm-gnueabihf": 12.2.0
+    "@next/swc-linux-arm64-gnu": 12.2.0
+    "@next/swc-linux-arm64-musl": 12.2.0
+    "@next/swc-linux-x64-gnu": 12.2.0
+    "@next/swc-linux-x64-musl": 12.2.0
+    "@next/swc-win32-arm64-msvc": 12.2.0
+    "@next/swc-win32-ia32-msvc": 12.2.0
+    "@next/swc-win32-x64-msvc": 12.2.0
+    "@swc/helpers": 0.4.2
     caniuse-lite: ^1.0.30001332
     postcss: 8.4.5
     styled-jsx: 5.0.2
+    use-sync-external-store: 1.1.0
   peerDependencies:
     fibers: ">= 3.1.0"
     node-sass: ^6.0.0 || ^7.0.0
@@ -26640,6 +26659,8 @@ __metadata:
     "@next/swc-darwin-arm64":
       optional: true
     "@next/swc-darwin-x64":
+      optional: true
+    "@next/swc-freebsd-x64":
       optional: true
     "@next/swc-linux-arm-gnueabihf":
       optional: true
@@ -26666,7 +26687,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 670d544fd47670c29681d10824e6da625e9d4a048e564c8d9cb80d37f33c9ff9b5ca0a53e6d84d8d618b1fe7c9bb4e6b45040cb7e57a5c46b232a8f914425dc1
+  checksum: 38456c33935122ac1581367e4982034be23269039a8470a66443d710334336f8f3fb587f25d172d138d84cf18c01d3a76627fb610c2e2e57bd1692277c23fa2b
   languageName: node
   linkType: hard
 
@@ -34785,7 +34806,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:~2.4.0":
+"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:~2.4.0":
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
   checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
@@ -35847,7 +35868,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.0.0":
+"use-sync-external-store@npm:1.1.0, use-sync-external-store@npm:^1.0.0":
   version: 1.1.0
   resolution: "use-sync-external-store@npm:1.1.0"
   peerDependencies:
@@ -36354,7 +36375,7 @@ __metadata:
     mongodb-memory-server: ^8.4.0
     mongoose: 6
     nanoid: ^3.1.25
-    next: ^12.1.6
+    next: latest
     next-connect: ^0.9.1
     next-i18next: ^8.10.0
     next-mdx-remote: 3


### PR DESCRIPTION
- http://localhost:3000/vn/examples/megaparam-demo only works with JS disabled, it then receive some HTML instead of .js when rehydrated
- You cannot redirect to a "GET" url from an Edge API handler using the POST method. So you have to use GET for your forms.
- The Set-Cookie header is not correctly handled, Chromium will only set the first cookie but not the other. Yet the header seems correct: `set-cookie: theme=light; Path=/, my_company=my_company; Path=/`
